### PR TITLE
Ignore new sub_issues.* events

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ var (
 		"repository_vulnerability_alerts.enable",
 		"repo.update_actions_secret",
 		"required_status_check.create",
+		"sub_issues.*",
 		"team.add_repository",
 		"workflows.*",
 	}


### PR DESCRIPTION
Quick PR to filter out events like `sub_issues.sub_issue_add` which are from the new sub-issue beta.